### PR TITLE
Remove @webi from the list: invalid certificate

### DIFF
--- a/we-are-twtxt.txt
+++ b/we-are-twtxt.txt
@@ -44,5 +44,4 @@ twtxt https://buckket.org/twtxt_news.txt
 tx https://0x1a4.1337.cx/twtxt.txt
 umonkey http://land.umonkey.net/twtxt.txt
 vinc https://vinc.cc/twtxt.txt
-webi https://twtxt.opstack.info/twtxt.txt
 xn https://xn.pinkhamster.net/twtxt.txt


### PR DESCRIPTION
The certificate of https://twtxt.opstack.info shows as expired, so `txtnish` doesn't get updates from there.