### PR TITLE
revert: remove alip and ionincognito

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,9 @@ me know if you want to be added.
 ## How to import the list
 
     xargs -n2 twtxt follow < we-are-twtxt.txt
+
+## Files
+
+  - `we-are-twtxt.txt` list of active twtxt users with working links
+  - `we-were-twtxt.txt` users with links that haven't been working for awhile
+  - `we-are-bots.txt` list of bots

--- a/we-are-twtxt.txt
+++ b/we-are-twtxt.txt
@@ -1,6 +1,7 @@
 71m https://timmorgan.org/twtxt.txt
 abliss https://abliss.keybase.pub/twtxt.txt#7a778276dd852edc65217e759cba637a28b4426b
 akraut https://akraut.keybase.pub/twtxt.txt
+alip https://dev.exherbo.org/~alip/twtxt.txt
 autoalk http://autoalk.tk/twtxt/autoalk.txt
 benaiah https://benaiah.me/twtxt.txt
 buckket https://buckket.org/twtxt.txt

--- a/we-were-twtxt.txt
+++ b/we-were-twtxt.txt
@@ -1,0 +1,1 @@
+ionincognito http://resistit.net/twtxt/twtxt.txt


### PR DESCRIPTION
Archive broken links instead of deleting them. We can periodically check
the broken link list and restore them.

> @xandkar: Looks like @alip is back online. Could be a good idea to
            archive rather than remove broken links.

Reverts-commit: f4f0866ccb9062740e99a394b2b2641f2f1eee75
Suggested-by: @xandkar
Signed-off-by: William Casarin <jb55@jb55.com>